### PR TITLE
go-to-parent, disable no_network policy, maintenance

### DIFF
--- a/curseradio/__init__.py
+++ b/curseradio/__init__.py
@@ -1,4 +1,4 @@
 __author__ = "Gordon Ball <gordon@chronitis.net>"
-__version__ = "0.2"
+__version__ = "0.3"
 
 from .curseradio import OPMLBrowser

--- a/curseradio/curseradio.py
+++ b/curseradio/curseradio.py
@@ -30,7 +30,7 @@ import re
 
 CONFIG_DEFAULT = {
     'opml': {'root': "http://opml.radiotime.com/"},
-    'playback': {'command': '/usr/local/bin/mpv'},
+    'playback': {'command': '/usr/bin/mpv'},
     'interface': {'keymap': 'default'},
     'keymap.default': {
         'up': 'KEY_UP',

--- a/curseradio/curseradio.py
+++ b/curseradio/curseradio.py
@@ -27,6 +27,7 @@ import xdg.BaseDirectory
 import configparser
 import re
 
+
 CONFIG_DEFAULT = {
     'opml': {'root': "http://opml.radiotime.com/"},
     'playback': {'command': '/usr/local/bin/mpv'},

--- a/curseradio/curseradio.py
+++ b/curseradio/curseradio.py
@@ -26,7 +26,6 @@ import pathlib
 import xdg.BaseDirectory
 import configparser
 import re
-import sys
 
 CONFIG_DEFAULT = {
     'opml': {'root': "http://opml.radiotime.com/"},

--- a/curseradio/curseradio.py
+++ b/curseradio/curseradio.py
@@ -60,7 +60,8 @@ class OPMLNode:
         is currently discarded).
         """
         if attr is None: attr = {}
-        tree = lxml.etree.parse(url)
+        parser = lxml.etree.XMLParser(dtd_validation=False, no_network=False)
+        tree = lxml.etree.parse(url, parser=parser)
         result = cls(text=text, attr=attr)
         result.children = [OPMLNode.from_element(o)
                            for o in tree.xpath('/opml/body/outline')]


### PR DESCRIPTION
Added "go to parent shortcut" and increased version (it makes OpenBSD curseradio port management easier).